### PR TITLE
Add shirt style selector between standard and street options

### DIFF
--- a/src/components/ui/PublishButton.tsx
+++ b/src/components/ui/PublishButton.tsx
@@ -142,7 +142,10 @@ function PublishModal({
                   >
                     <div className="flex items-center gap-3">
                       <RadioGroupItem value="standard" id="standard" />
-                      <span className="text-sm font-medium">Standard</span>
+                      <div>
+                        <span className="text-sm font-medium">Standard</span>
+                        <p className="text-xs text-muted-foreground">Comfort Colors &middot; soft, relaxed fit</p>
+                      </div>
                     </div>
                     <span className="text-xs text-muted-foreground">
                       {standardInfo.priceFormatted}
@@ -158,7 +161,10 @@ function PublishModal({
                   >
                     <div className="flex items-center gap-3">
                       <RadioGroupItem value="street" id="street" />
-                      <span className="text-sm font-medium">Street Style</span>
+                      <div>
+                        <span className="text-sm font-medium">Street Style</span>
+                        <p className="text-xs text-muted-foreground">Shaka Wear &middot; heavyweight, oversized</p>
+                      </div>
                     </div>
                     <span className="text-xs text-muted-foreground">
                       {streetInfo.priceFormatted}
@@ -411,6 +417,7 @@ export function PublishButton() {
         user,
         shirtData.prompt,
         promptChain,
+        selectedShirtStyle,
       );
 
       // Update lifecycle to PUBLISHING before creating product

--- a/src/lib/productDescription.ts
+++ b/src/lib/productDescription.ts
@@ -1,4 +1,5 @@
 import type { EchoUser } from "@merit-systems/echo-react-sdk";
+import type { ShirtStyle } from "@/services/printify/types";
 
 /**
  * Format a prompt chain into a numbered list for product descriptions
@@ -25,10 +26,21 @@ export const formatPromptChain = (promptChain: string[]): string => {
   return formattedSteps;
 };
 
+/**
+ * Get shirt style details for product descriptions
+ */
+const getShirtDetails = (shirtStyle: ShirtStyle): string => {
+  if (shirtStyle === "street") {
+    return `Printed on Shaka Wear Max Heavyweight 7.5 oz tees — thick, oversized streetwear fit.`;
+  }
+  return `Printed on 100% ring-spun cotton Comfort Colors tees — soft-washed, garment-dyed, relaxed fit.`;
+};
+
 export const PRODUCT_DESCRIPTION_TEMPLATE = (
   creator: EchoUser | null,
   prompt?: string,
   promptChain?: string[],
+  shirtStyle: ShirtStyle = "standard",
 ) => {
   // Use prompt chain if available, otherwise fall back to single prompt
   const designText =
@@ -38,8 +50,11 @@ export const PRODUCT_DESCRIPTION_TEMPLATE = (
         ? `<em>"${prompt}"</em>`
         : "";
 
+  const shirtDetails = getShirtDetails(shirtStyle);
+
   return `
 Created on <a href="https://shirtslop.com" target="_blank" rel="noopener noreferrer">shirtslop.com</a>
+<br><br>${shirtDetails}
 ${designText ? `<br><br>Design Evolution:<br>${designText}` : ""}
 ${creator ? `<br><br>by: ${creator.name || creator.email}` : ""}
 ${creator?.id ? `<br><br><span style="color: #888;">[${creator.id}]</span>` : ""}

--- a/src/services/printify.ts
+++ b/src/services/printify.ts
@@ -165,6 +165,7 @@ class PrintifyService {
     const productDescription = ProductBuilder.createDescription(
       identifier,
       description,
+      shirtStyle,
     );
     const payload = ProductBuilder.createProductPayload(
       productName,

--- a/src/services/printify/ProductBuilder.ts
+++ b/src/services/printify/ProductBuilder.ts
@@ -80,11 +80,15 @@ export class ProductBuilder {
   static createDescription(
     identifier: string,
     customDescription?: string,
+    shirtStyle: ShirtStyle = "standard",
   ): string {
-    return (
-      customDescription ||
-      `Created on <a href="https://shirtslop.com" target="_blank">https://shirtslop.com</a>\n\nShirtSlop Tees\nSo Soft. So Shirt. So Slop.\n\nAt ShirtSlop, we take your ideas, inside jokes, and designs — and print them on Comfort Colors tees.\n\nProduct Details:\n– Printed on 100% ring-spun cotton Comfort Colors tees\n– Pre-shrunk, soft-washed, garment-dyed fabric\n– Relaxed fit with vintage fade\n– Double-stitched for durability\n– Unisex sizing: comfortable, built for slopping\n\nID: ${identifier}`
-    );
+    if (customDescription) return customDescription;
+
+    if (shirtStyle === "street") {
+      return `Created on <a href="https://shirtslop.com" target="_blank">https://shirtslop.com</a>\n\nShirtSlop Tees\nSo Soft. So Shirt. So Slop.\n\nAt ShirtSlop, we take your ideas, inside jokes, and designs — and print them on Shaka Wear heavyweight tees.\n\nProduct Details:\n– Printed on Shaka Wear Max Heavyweight 7.5 oz tees\n– 100% cotton, extra thick and durable\n– Oversized streetwear fit\n– Double-stitched for durability\n– Unisex sizing: comfortable, built for slopping\n\nID: ${identifier}`;
+    }
+
+    return `Created on <a href="https://shirtslop.com" target="_blank">https://shirtslop.com</a>\n\nShirtSlop Tees\nSo Soft. So Shirt. So Slop.\n\nAt ShirtSlop, we take your ideas, inside jokes, and designs — and print them on Comfort Colors tees.\n\nProduct Details:\n– Printed on 100% ring-spun cotton Comfort Colors tees\n– Pre-shrunk, soft-washed, garment-dyed fabric\n– Relaxed fit with vintage fade\n– Double-stitched for durability\n– Unisex sizing: comfortable, built for slopping\n\nID: ${identifier}`;
   }
 
   /**


### PR DESCRIPTION
Closes #74

The publish modal already had a basic radio toggle for shirt style, but the product descriptions were hardcoded to always mention Comfort Colors regardless of which style was picked. This fixes that and cleans up the selector UI.

Changes:
- Product descriptions now reflect the actual shirt style (Comfort Colors vs Shaka Wear details)
- `PRODUCT_DESCRIPTION_TEMPLATE` accepts `shirtStyle` param and includes the right fabric/fit info
- `ProductBuilder.createDescription` fallback also uses the correct style-specific copy
- Radio buttons in the publish modal now show brand name + short description (e.g. "Comfort Colors · soft, relaxed fit")