### PR TITLE
Fix GPT Image 2 generation requests

### DIFF
--- a/src/hooks/useImageGeneration.ts
+++ b/src/hooks/useImageGeneration.ts
@@ -144,8 +144,6 @@ export function useImageGeneration(
           partial_images: QUALITY_LEVELS[quality].partial_images,
           moderation: "low",
           background: "opaque",
-          input_fidelity:
-            base64Images && base64Images.length > 0 ? "high" : "low",
         },
       ],
     } as unknown; // Type assertion for custom Echo API format


### PR DESCRIPTION
## Summary

- remove the unsupported input_fidelity option from image generation tool requests
- keep existing quality, size, moderation, and opaque background settings unchanged
- allow both new generations and image edits to use gpt-image-2 without a 400 response

## Verification

- npm run build
- npm run lint
- npx prettier --check src/hooks/useImageGeneration.ts
- git diff --check -- src/hooks/useImageGeneration.ts